### PR TITLE
Add Multiplex and example file to run.sh

### DIFF
--- a/uperf/run.sh
+++ b/uperf/run.sh
@@ -27,6 +27,10 @@ samples=3 # Ideally use at least 3 samples for each benchmark iteration.
             #  from other runs, for example:  "cloud-reservation:48,HT:off,CVE:off"
             # Note that many tags are auto-generated below
 
+benchmark_config_file="multiplex_input.json" # clone https://github.com/perftool-incubator/multiplex.git
+                                             # copy multiplex.py to this directory
+                                             # see uperf-multiplex-example.json for an example config file
+
 # Variables for ocp/k8s environments
 ####################################
 num_cpus=40  # Number of *available* cpus on each of the workers.
@@ -108,10 +112,10 @@ else
     anno_opt=""
 fi
 
+./multiplex.py --input $benchmark_config_file > bench-params.json
 
 
 for num_pods in $scale_up_factor; do
-    sed -e s/thisIfname/$server_ifname/ bench-params.template >bench-params.json
     num_clients=`echo "$num_pods * $scale_out_factor" | bc`
     num_servers=$num_clients
     if [ "$topo" != "interhost" ]; then # Any test involving ocp/k8s

--- a/uperf/run.sh
+++ b/uperf/run.sh
@@ -27,9 +27,7 @@ samples=3 # Ideally use at least 3 samples for each benchmark iteration.
             #  from other runs, for example:  "cloud-reservation:48,HT:off,CVE:off"
             # Note that many tags are auto-generated below
 
-benchmark_config_file="multiplex_input.json" # clone https://github.com/perftool-incubator/multiplex.git
-                                             # copy multiplex.py to this directory
-                                             # see uperf-multiplex-example.json for an example config file
+benchmark_config_file="uperf-multiplex-example.json"
 
 # Variables for ocp/k8s environments
 ####################################

--- a/uperf/run.sh
+++ b/uperf/run.sh
@@ -112,8 +112,6 @@ else
     anno_opt=""
 fi
 
-./multiplex.py --input $benchmark_config_file > bench-params.json
-
 
 for num_pods in $scale_up_factor; do
     num_clients=`echo "$num_pods * $scale_out_factor" | bc`
@@ -217,5 +215,5 @@ for num_pods in $scale_up_factor; do
     if [ ! -z "$other_tags" ]; then
         tags+="other_tags"
     fi
-    crucible run uperf --tags $tags --num-samples=$samples $endpoint_opt
+    crucible run uperf --mv-params $benchmark_config_file --tags $tags --num-samples=$samples $endpoint_opt
 done

--- a/uperf/uperf-multiplex-example.json
+++ b/uperf/uperf-multiplex-example.json
@@ -1,26 +1,26 @@
 {
-    "common": [
-    {
-        "name":"global",
-        "params": [
-            { "arg": "duration", "vals": [ "90" ] },
-            { "arg": "protocol", "vals": [ "tcp" ] },
-            { "arg": "nthreads", "vals": [ "1","16","64" ] },
-            { "arg": "server-ifname", "vals": [ "eth0" ] }
-        ]
-    }
+    "global-options": [
+        {
+            "name": "global",
+            "params": [
+                { "arg": "duration", "vals": ["90"] },
+                { "arg": "protocol", "vals": ["tcp"] },
+                { "arg": "nthreads", "vals": ["1", "16", "64"] },
+                { "arg": "server-ifname", "vals": ["eth0"] }
+            ]
+        }
     ],
     "sets": [
         [
-            { "common": "global"},
-            { "arg": "test-type", "vals": [ "stream" ] },
-            { "arg": "wsize", "vals": [ "64", "16384" ] }
+            {"include": "global"},
+            { "arg": "test-type", "vals": ["stream"] },
+            { "arg": "wsize", "vals": ["64", "16384"] }
         ],
         [
-            { "common": "global"},
-            { "arg": "test-type", "vals": [ "rr" ] },
-            { "arg": "wsize", "vals": [ "64" ] },
-            { "arg": "rsize", "vals": [ "1024","16384" ] }
+            {"include": "global"},
+            { "arg": "test-type", "vals": ["rr"] },
+            { "arg": "wsize", "vals": ["64"] },
+            { "arg": "rsize", "vals": ["1024", "16384"] }
         ]
     ]
 }

--- a/uperf/uperf-multiplex-example.json
+++ b/uperf/uperf-multiplex-example.json
@@ -3,21 +3,21 @@
     {
         "name":"global",
         "params": [
-        { "arg": "duration", "vals": [ "90" ] },
-        { "arg": "protocol", "vals": [ "tcp" ] },
-        { "arg": "nthreads", "vals": [ "1","16","64" ] },
-        { "arg": "server-ifname", "vals": [ "eth0" ] }
-    ]
+            { "arg": "duration", "vals": [ "90" ] },
+            { "arg": "protocol", "vals": [ "tcp" ] },
+            { "arg": "nthreads", "vals": [ "1","16","64" ] },
+            { "arg": "server-ifname", "vals": [ "eth0" ] }
+        ]
     }
     ],
     "sets": [
         [
-        { "common": "global"},
+            { "common": "global"},
             { "arg": "test-type", "vals": [ "stream" ] },
             { "arg": "wsize", "vals": [ "64", "16384" ] }
         ],
         [
-        { "common": "global"},
+            { "common": "global"},
             { "arg": "test-type", "vals": [ "rr" ] },
             { "arg": "wsize", "vals": [ "64" ] },
             { "arg": "rsize", "vals": [ "1024","16384" ] }

--- a/uperf/uperf-multiplex-example.json
+++ b/uperf/uperf-multiplex-example.json
@@ -1,0 +1,27 @@
+{
+    "common": [
+    {
+        "name":"global",
+        "params": [
+        { "arg": "duration", "vals": [ "90" ] },
+        { "arg": "protocol", "vals": [ "tcp" ] },
+        { "arg": "nthreads", "vals": [ "1","16","64" ] },
+        { "arg": "server-ifname", "vals": [ "eth0" ] }
+    ]
+    }
+    ],
+    "sets": [
+        [
+        { "common": "global"},
+            { "arg": "test-type", "vals": [ "stream" ] },
+            { "arg": "wsize", "vals": [ "64", "16384" ] }
+        ],
+        [
+        { "common": "global"},
+            { "arg": "test-type", "vals": [ "rr" ] },
+            { "arg": "wsize", "vals": [ "64" ] },
+            { "arg": "rsize", "vals": [ "1024","16384" ] }
+        ]
+    ]
+}
+


### PR DESCRIPTION
This adds a call to multiplex and an example config file. This might not be the desired way to call multiplex as it would require the user to clone and copy the python file to the local dir, but its a start. 