### PR TITLE
Flexran: Initial commit

### DIFF
--- a/flexran/README.md
+++ b/flexran/README.md
@@ -1,0 +1,204 @@
+# FlexRAN Benchmark
+
+## Intro
+Intel FlexRAN is a 4G and 5G baseband PHY/L1 Reference platform. See [https://github.com/intel/FlexRAN](https://github.com/intel/FlexRAN).
+
+In the current form, an Intel FlexRAN release comprises of the L1 source code, the adaptation s/w to
+interface to the hardware-assisted FEC PCI cards i.e N3000 or ACC100 cards, and the Testmac (the L2 test harness).
+
+## Limitations
+Comparing to other crucible benchmarks i.e. uperf, fio etc, the crucible FlexRAN benchmark in the surrect state has several
+limitations and/or extra prerequisites.
+
+- FlexRAN S/W must be prebuilt outside of crucible workshop
+- Support OCP only (No server support)
+- Container must mount FlexRAN S/W from worker node.
+- Indexing to ES only a few metrics. Full FlexRAN results available in the log files.
+
+### Setup The Testbed
+
+1. Building FlexRAN software
+
+	As mentioned above, a FlexRAN release comes with S/W in source. One must have a mean (Intel contact) to obtain a FlexRAN release.
+In addition, to compile FlexRAN, one must use the ICC compiler which requires a license itself. Hence the artifacts of the build
+are not public accessed deliverables. Because of these unsettling issues, we keep the FlexRAN build process out of crucible workshop.
+
+2. Setup the OCP cluster to host FlexRAN
+
+	Currently, crucible FlexRAN benchmark only supports k8s endpoint type. This purely is a requirement call.
+
+	FlexRAN can run  w/o a h/w assisted FEC device, but this mode has no usefulness for our purposes. Hence the first
+thing to do is to install and configure your h/w-assisted FEC device by following the instructions in the release.
+
+3. Prepare the worker node
+
+	Next, copy FlexRAN build contents to worker node. Note that this step prepares the worker node
+for the container to mount and get access to the FlexRAN build blob.  This strategy is not a requirement, but a measure
+to overcome the size (100GB) of the build blob which significant slows down the container image build/push/pull.
+
+	The build process in step 1 produces a flexran blob comprised of 3 directories: ./flexran, ./intel and ./dpdk-<version>
+	Copy (scp) these 3 directories to the worker node's /opt
+
+## How to run FlexRAN benchmark
+
+### Running Default Tests.
+	$ bash run.sh
+
+Testmac run CLI format is as follows:
+	
+    $ run [test_type: 0-DL 1-UL 2-FD] [Numerology] [Bandwidth] Test_num]
+
+A 'bash run.sh' will kick off 3 iterations:
+
+1. runall 0 0 5         - The equivalent to run 0 0 5 [all-test]
+2. run 2 0 5 1001       - run test 1001
+3. run a list of tests specified by "/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg"
+
+### Running Custom Tests.
+Let us first explore the configuration files.
+
+#### annotations.json
+For configuring low-latency app. This file should not be changed.
+
+#### resources.json
+FlexRAN L1 has 5 threadds. and Testmac has 4. Currently the helper script expects a minimum of 9 cores and automatically pin the first 9 cores to those 9 threads. The script will error out if detecting less than 9 cores being allocated to the pod.
+
+#### securityContext.json
+No changes.
+
+#### volumes.json and volumeMounts.json
+These two files set up hugepage and host mount. No customization
+
+#### tool-params.json
+Can be changed to include more or less tools
+
+#### mv-params.json
+In manual mode, one can initiate tests from the Testmac console.
+
+	TESTMAC > run [test_type: 0-DL 1-UL 2-FD] [Numerology] [Bandwidth] [optional: test_num]
+
+For example
+
+	TESTNMAC> run 2 0 5 1001
+    
+In a script mode, one can invoke Testmac with the TESTFILE env specifying the test config. For example:
+    
+    $ TESTFILE=/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg l2.sh
+
+In above command, l2.sh is the front-end of Testmac, and 'testmac_fd_mu0_5mhz.cfg' contains a list of tests to run.
+
+#### mv-params.json
+implements both the manual mode and the script mode for crucible FlexRAN
+
+To specify a manual mode run
+
+            "params": [
+                { "arg": "fec-mode", "vals": ["hw"], "role": "client" },
+                { "arg": "usr1", "vals": ["runall"], "role": "client" },
+                { "arg": "usr2", "vals": ["2"], "role": "client" },
+                { "arg": "usr3", "vals": ["0"], "role": "client" },
+                { "arg": "usr4", "vals": ["5"], "role": "client" },
+                { "arg": "log-test", "vals": ["FD_1001"], "role": "client" }
+            ]
+
+To specify a script run:
+
+            "params": [
+                { "arg": "fec-mode", "vals": ["hw"], "role": "client" },
+                { "arg": "test-file", "vals": ["/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg"], "role": "client" },
+                { "arg": "log-test", "vals": ["FD_12001"], "role": "client" }
+            ]
+
+- vals is an array. For each value in the array, crucible run a test iteration.
+
+ - fec-mode: valid value are "hw" and "sw" - As mentioned previously, flexran can run with or w/o FEC hardware. When fec-mode value is "sw", the L1 invokes its s/w-emulated method for the FEC function.
+
+- 'useN' and 'test-file' are used to specify manual-mode and script-mode
+
+- log-test: when we invoke 'runall' or  script mode "TESTFIEL=xxx ./l2.sh", the workload runs multiple tests. Currently the helper script only indexes one metric of one test. The 'log-test'  variable specifis that test. The vaild values of log-test are the test names i.e FD_1001.
+    
+ 
+# Crucible Run Results
+
+
+    run-id: EE6A7104-1D5D-11EC-B0D7-66F060E020CC
+      tags:
+      metrics:
+        source: procstat
+          types: interrupts-sec
+        source: mpstat
+          types: Busy-CPU NonBusy-CPU
+        source: sar-net
+          types: packets-sec L2-Gbps errors-sec
+        source: iostat
+          types: avg-queue-length avg-req-size-kB avg-service-time-ms kB-sec operations-sec percent-utilization operations-merged-sec percent-merged
+        source: sar-scheduler
+          types: Load-Average-01m Load-Average-05m Load-Average-15m Process-List-Size Run-Queue-Length IO-Blocked-Tasks %-Time-Tasks-CPU-Starved-last_interval
+        source: sar-mem
+          types: Page-faults-sec KB-Paged-out-sec Pages-freed-sec %-Time-Non-Idle-Tasks-Stalled-on-Memory-300s %-Time-Tasks-Waiting-on-Memory-010s %-Time-Tasks-Waiting-on-Memory-300s %-Time-Taast_interval kswapd-scanned-pages-sec
+        source: flexran
+          types: DL UL
+        source: sar-tasks
+          types: Context-switches-sec Processes-created-sec
+        source: sar-io
+          types: %-Time-Tasks-Lost-Waiting-on-IO-300s %-Time-Tasks-Stalled-Waiting-on-IO-300s
+      iterations:
+        iteration-id: 7C71B65E-1D60-11EC-AFB5-18FE60E020CC
+          params: fec-mode=hw log-test=FD_1001 usr1=runall usr2=2 usr3=0 usr4=5
+          primary-period name: measurement
+          samples:
+            sample-id: 7C7540B2-1D60-11EC-AFB5-18FE60E020CC
+              primary period-id: 7C75FDFE-1D60-11EC-AFB5-18FE60E020CC
+              period range: begin: 1632505337758 end: 1632505970825
+            result: (DL) samples: 54.11 mean: 54.11 min: 54.11 max: 54.11 stddev: NaN stddevpct: NaN
+        iteration-id: 7C7DCAE8-1D60-11EC-AFB5-18FE60E020CC
+          params: fec-mode=hw log-test=FD_1001 usr1=run usr2=2 usr3=0 usr4=5 usr5=1001
+          primary-period name: measurement
+          samples:
+            sample-id: 7C815262-1D60-11EC-AFB5-18FE60E020CC
+              primary period-id: 7C81DBC4-1D60-11EC-AFB5-18FE60E020CC
+              period range: begin: 1632505104585 end: 1632505161612
+            result: (DL) samples: 53.33 mean: 53.33 min: 53.33 max: 53.33 stddev: NaN stddevpct: NaN
+        iteration-id: 7C886692-1D60-11EC-AFB5-18FE60E020CC
+          params: fec-mode=hw log-test=FD_12001 test-file=/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg
+          primary-period name: measurement
+          samples:
+            sample-id: 7C89D202-1D60-11EC-AFB5-18FE60E020CC
+              primary period-id: 7C8A524A-1D60-11EC-AFB5-18FE60E020CC
+              period range: begin: 1632505210654 end: 1632505288683
+            result: (DL) samples: 66.63 mean: 66.63 min: 66.63 max: 66.63 stddev: NaN stddevpct: Na
+
+
+
+# Raw FlexRAN Results:
+The raw results are found in similar file path as:
+
+		/var/lib/crucible/run/latest/run/iterations/iteration-1/sample-1/client/
+        
+This directory contains result files generated by Intel FlexRAN itself, and files generated by crucible FlexRAN benchmark
+
+The major crucible FlexRAN files are:
+
+ - post-process-output.txt   - logs of result processing
+
+ - flexran-client.log   - logs of FlexRAN container
+
+The major Intel FlexRAN result files are:
+
+ - l1_mlog_stats.txt  - contains the most important results of all
+ - Results.txt  - a listing of the tests ran
+ - l1m*			- l1 results
+ - PhyStats*    - Phy results from L1 and Testmac
+
+
+# Querying Crucible ES for Past Results
+
+
+ 	$ crucible get metric --source flexran --type <UL/DL> --period <> --begin <> --end <> --breakout type
+
+
+
+
+-- EOF ---
+
+

--- a/flexran/README.md
+++ b/flexran/README.md
@@ -7,7 +7,7 @@ In the current form, an Intel FlexRAN release comprises of the L1 source code, t
 interface to the hardware-assisted FEC PCI cards i.e N3000 or ACC100 cards, and the Testmac (the L2 test harness).
 
 ## Limitations
-Comparing to other crucible benchmarks i.e. uperf, fio etc, the crucible FlexRAN benchmark in the surrect state has several
+Comparing to other crucible benchmarks i.e. uperf, fio etc, the crucible FlexRAN benchmark in the current state has several
 limitations and/or extra prerequisites.
 
 - FlexRAN S/W must be prebuilt outside of crucible workshop
@@ -21,7 +21,7 @@ limitations and/or extra prerequisites.
 
 	As mentioned above, a FlexRAN release comes with S/W in source. One must have a mean (Intel contact) to obtain a FlexRAN release.
 In addition, to compile FlexRAN, one must use the ICC compiler which requires a license itself. Hence the artifacts of the build
-are not public accessed deliverables. Because of these unsettling issues, we keep the FlexRAN build process out of crucible workshop.
+are not public deliverables. Because of these unsettling issues, we keep the FlexRAN build process out of crucible workshop.
 
 2. Setup the OCP cluster to host FlexRAN
 
@@ -58,13 +58,13 @@ A 'bash run.sh' will kick off 3 iterations:
 Let us first explore the configuration files.
 
 #### annotations.json
-For configuring low-latency app. This file should not be changed.
+For configuring low-latency app. No customization here.
 
 #### resources.json
 FlexRAN L1 has 5 threadds. and Testmac has 4. Currently the helper script expects a minimum of 9 cores and automatically pin the first 9 cores to those 9 threads. The script will error out if detecting less than 9 cores being allocated to the pod.
 
 #### securityContext.json
-No changes.
+No customization.
 
 #### volumes.json and volumeMounts.json
 These two files set up hugepage and host mount. No customization
@@ -79,9 +79,9 @@ In manual mode, one can initiate tests from the Testmac console.
 
 For example
 
-	TESTNMAC> run 2 0 5 1001
+	TESTMAC> run 2 0 5 1001
     
-In a script mode, one can invoke Testmac with the TESTFILE env specifying the test config. For example:
+In a script mode, one can invoke Testmac with the TESTFILE env specifying the test config file. For example:
     
     $ TESTFILE=/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg l2.sh
 
@@ -109,13 +109,13 @@ To specify a script run:
                 { "arg": "log-test", "vals": ["FD_12001"], "role": "client" }
             ]
 
-- vals is an array. For each value in the array, crucible run a test iteration.
+- vals is an array. For each value in the array, crucible orchestratrates one test iteration.
 
- - fec-mode: valid value are "hw" and "sw" - As mentioned previously, flexran can run with or w/o FEC hardware. When fec-mode value is "sw", the L1 invokes its s/w-emulated method for the FEC function.
+ - fec-mode: valid values are "hw" and "sw" - As mentioned previously, flexran can run with or w/o FEC hardware. When fec-mode value is "sw", the L1 invokes its s/w-emulated method to perform the FEC function.
 
-- 'useN' and 'test-file' are used to specify manual-mode and script-mode
+- 'useN' and 'test-file' support manual-mode and script-mode accordingly.
 
-- log-test: when we invoke 'runall' or  script mode "TESTFIEL=xxx ./l2.sh", the workload runs multiple tests. Currently the helper script only indexes one metric of one test. The 'log-test'  variable specifis that test. The vaild values of log-test are the test names i.e FD_1001.
+- log-test: when we invoke 'runall' or script mode, "TESTFIEL=xxx ./l2.sh", the benchmark runs multiple tests. Currently the helper script only indexes one metric of one test. The 'log-test' variable specifies that test. The valid values for log-test are the test names i.e FD_1001.
     
  
 # Crucible Run Results

--- a/flexran/annotations.json
+++ b/flexran/annotations.json
@@ -1,0 +1,4 @@
+"annotations": {
+  "irq-load-balancing.crio.io": "disable",
+  "cpu-quota.crio.io": "disable"
+}

--- a/flexran/mv-params.json
+++ b/flexran/mv-params.json
@@ -1,0 +1,43 @@
+{
+    "global-options": [
+        {
+            "name": "global",
+            "params": [
+                { "arg": "reserved", "vals": ["none"], "role": "server" }
+            ]
+        }
+    ],
+    "sets": [
+        {
+            "params": [
+                { "arg": "fec-mode", "vals": ["hw"], "role": "client" },
+                { "arg": "usr1", "vals": ["runall"], "role": "client" },
+                { "arg": "usr2", "vals": ["2"], "role": "client" },
+                { "arg": "usr3", "vals": ["0"], "role": "client" },
+                { "arg": "usr4", "vals": ["5"], "role": "client" },
+                { "arg": "log-test", "vals": ["FD_1001"], "role": "client" }
+            ]
+        },
+
+        {
+            "params": [
+                { "arg": "fec-mode", "vals": ["hw"], "role": "client" },
+                { "arg": "usr1", "vals": ["run"], "role": "client" },
+                { "arg": "usr2", "vals": ["2"], "role": "client" },
+                { "arg": "usr3", "vals": ["0"], "role": "client" },
+                { "arg": "usr4", "vals": ["5"], "role": "client" },
+                { "arg": "usr5", "vals": ["1001"], "role": "client" },
+                { "arg": "log-test", "vals": ["FD_1001"], "role": "client" }
+            ]
+
+        },
+
+        {
+            "params": [
+                { "arg": "fec-mode", "vals": ["hw"], "role": "client" },
+                { "arg": "test-file", "vals": ["/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg"], "role": "client" },
+                { "arg": "log-test", "vals": ["FD_12001"], "role": "client" }
+            ]
+        }
+    ]
+}

--- a/flexran/resources.json
+++ b/flexran/resources.json
@@ -1,0 +1,14 @@
+"resources": {
+    "requests": {
+        "cpu": "32",
+        "memory": "32Gi",
+        "hugepages-1Gi": "16Gi",
+        "intel.com/intel_fec_5g": "1"
+    },
+    "limits": {
+        "cpu": "32",
+        "memory": "32Gi",
+        "hugepages-1Gi": "16Gi",
+        "intel.com/intel_fec_5g": "1"
+    }
+}

--- a/flexran/run.sh
+++ b/flexran/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# ocp admin node
+k8shost1=xxx.yyy.zzz
+
+resources_file="`/bin/pwd`/resources.json"
+annotations_file="`/bin/pwd`/annotations.json"
+securityContext_file="`/bin/pwd`/securityContext.json"
+volumeMounts_file="`/bin/pwd`/volumeMounts.json"
+volumes_file="`/bin/pwd`/volumes.json"
+
+# set the number of samples for your run
+samples=1
+
+crucible run flexran \
+  --mv-params mv-params.json \
+  --num-samples ${samples} \
+  --max-sample-failures ${samples} \
+  --test-order r \
+  --endpoint k8s,host:$k8shost1,user:kni,client:1,userenv:stream,cpu-partitioning:default:1,resources:client-1:$resources_file,annotations:client-1:$annotations_file,securityContext:client-1:$securityContext_file,hugepage:1,volumeMounts:client-1:$volumeMounts_file,volumes:client-1:$volumes_file
+

--- a/flexran/securityContext.json
+++ b/flexran/securityContext.json
@@ -1,0 +1,6 @@
+"securityContext": {
+  "privileged": true,
+  "capabilities": {
+    "add": [ "SYS_ADMIN", "IPC_LOCK", "SYS_NICE", "SYS_ADMIN" ]
+  }
+}

--- a/flexran/tool-params.json
+++ b/flexran/tool-params.json
@@ -1,0 +1,8 @@
+[
+    {
+        "tool": "sysstat"
+    },
+    {
+        "tool": "procstat"
+    }
+]

--- a/flexran/volumeMounts.json
+++ b/flexran/volumeMounts.json
@@ -1,0 +1,6 @@
+"volumeMounts": [
+  { "mountPath": "/dev/hugepages", "name": "hugepage" },
+  { "mountPath": "/var/run/dpdk", "name": "varrun" }, 
+  { "mountPath": "/tmp/opt",         "name": "opt" }
+]
+

--- a/flexran/volumes.json
+++ b/flexran/volumes.json
@@ -1,0 +1,6 @@
+"volumes": [
+ { "name": "hugepage", "emptyDir": { "medium": "HugePages" } },
+ { "name": "varrun", "emptyDir": {} },
+ { "name": "opt", "hostPath": { "path": "/opt/" } }
+]
+


### PR DESCRIPTION
Issue: This is the initial Flexran commit.

Description:

1. run.sh  -  'bash run.sh' to run flexran workload. 
2. annotations.json  - For low latency
4. mv-params.json  - This file produces 3 iteration: 'runall 0 0 5', 'run 2 0 5 1001', and run a suite specified by '/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg
 5. resources.json -  CPU, mem and FEC h/w required resources
6. securityContext.json
7. tool-params.json
8. volumeMounts.json - For DPDK and devel flexran hostPath mount
9. volumes.json - For DPDK and flexran hostPath mount

Prerequisite:

1. At the moment, the container image does not contains Flexran S/W since it is big, ~100GB (bytes!).  Instead, we copy flexran S/W to worker node(s) and make the k8s endpoints's container mount it.  
2. To run with HW FEC the worker node must have H/W FEC i.e N3000 installed and properly configured i.e flash and ONEness SRIOV operator.
 