### PR TITLE
fixing syntax of tool-params.json in uperf example

### DIFF
--- a/uperf/tool-params.json
+++ b/uperf/tool-params.json
@@ -1,7 +1,7 @@
 [
   { "tool": "ovs" },
   { "tool": "kernel",
-    "params": [ {"arg":"subtools","val":"perf"}, { "arg": "perf-record-opts", "val": "--freq=100 --namespaces --all-cgroups" } ]
+    "params": [ {"arg":"subtools","val":"perf"}, { "arg": "record-opts", "val": "--freq=100 --namespaces --all-cgroups" } ]
   },
   { "tool": "sysstat" },
   { "tool": "procstat" }


### PR DESCRIPTION
With the current syntax, opts are ignored