### PR TITLE
fix: remove --from-file from run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ details about the Crucible runfile can be found in the [runfile doc](runfile/REA
 
 # Running a benchmark with Crucible
 ```
-crucible run --from-file <run-file-name>.json
+crucible run <run-file-name>.json
 ```
 
 ## Result summary

--- a/runfile/README.md
+++ b/runfile/README.md
@@ -8,7 +8,7 @@ in the same JSON file. For example, to test `oslat` with Crucible
 using one single JSON config, run:
 
 ```
-crucible run --from-file oslat-k8s-runfile.json
+crucible run oslat-k8s-runfile.json
 ```
 
 ## Naming standards

--- a/runfile/fio/run.sh
+++ b/runfile/fio/run.sh
@@ -50,4 +50,4 @@ replace_value int samples ${samples} '."run-params"."num-samples" = $samples'
 replace_value int samples ${samples} '."run-params"."max-sample-failures" = $samples'
 
 ## execution command
-crucible run --from-file fio.json
+crucible run fio.json


### PR DESCRIPTION
## Summary

Remove the legacy `--from-file` parameter from all run examples, using the simpler `crucible run <file>.json` syntax.

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)